### PR TITLE
Some minor clean up and some TPL love

### DIFF
--- a/src/Chassis/Apps/ApplicationInstance.cs
+++ b/src/Chassis/Apps/ApplicationInstance.cs
@@ -2,31 +2,20 @@
 using System.Collections.Generic;
 using Autofac;
 using Chassis.Env;
-using Chassis.Features;
 using Chassis.Introspection;
 using Chassis.Startup;
-using Chassis.Tenants;
 using Chassis.Types;
 
 namespace Chassis.Apps
 {
-    public class ApplicationInstance : IApplication, Rebootable
+    public class ApplicationInstance : IApplicationInstance, Rebootable
     {
         readonly IContainer _container;
         readonly TypePool _pool;
 
         public ApplicationInstance(IContainer container,
-            TypePool pool,
-            IEnumerable<Feature> features,
-            IEnumerable<Module> modules,
-            IEnumerable<TenantOverrides> tenantOverrides,
-            TimeSpan bootTime)
+            TypePool pool)
         {
-            LoadedFeatures = features;
-            LoadedModules = modules;
-            LoadedTenants = tenantOverrides;
-            TimeToBoot = bootTime;
-
             _container = container;
 
             _pool = pool;
@@ -103,11 +92,6 @@ namespace Chassis.Apps
 
         public IContainer Container => _container;
 
-        public IEnumerable<Module> LoadedModules { get; }
-        public IEnumerable<Feature> LoadedFeatures { get; }
-        public IEnumerable<TenantOverrides> LoadedTenants { get; }
-
-        public TimeSpan TimeToBoot { get; private set; }
 
         public void Probe(IProbeContext context)
         {

--- a/src/Chassis/Apps/IApplicationDefinition.cs
+++ b/src/Chassis/Apps/IApplicationDefinition.cs
@@ -3,7 +3,7 @@ using Chassis.Types;
 
 namespace Chassis.Apps
 {
-    public interface IApplicationMarker
+    public interface IApplicationDefinition
     {
         void ConfigureContainer(TypePool pool, ContainerBuilder builder);
     }

--- a/src/Chassis/Apps/IApplicationInstance.cs
+++ b/src/Chassis/Apps/IApplicationInstance.cs
@@ -1,23 +1,19 @@
 ﻿using System;
-using System.Collections.Generic;
 using Autofac;
-using Chassis.Features;
 using Chassis.Introspection;
-using Chassis.Tenants;
 
 namespace Chassis.Apps
 {
-    public interface IApplication : IDisposable, IProbeSite
+    public interface IApplicationInstance : IDisposable, IProbeSite
     {
-        IContainer Container { get; }
         void Start();
+
+        // TODO: Remove this items below
+
+        IContainer Container { get; }
         TComponent Resolve<TComponent>();
         TComponent Resolve<TComponent>(string named);
         void Scope(Action<ILifetimeScope> scope);
         TResponse Dispatch<TRequest, TResponse>(TRequest request) where TRequest : class, IRequest;
-
-        IEnumerable<Module> LoadedModules { get; }
-        IEnumerable<Feature> LoadedFeatures { get; }
-        IEnumerable<TenantOverrides> LoadedTenants { get; }
     }
 }

--- a/src/Chassis/Chassis.csproj
+++ b/src/Chassis/Chassis.csproj
@@ -58,8 +58,8 @@
   <ItemGroup>
     <Compile Include="Apps\AppFactory.cs" />
     <Compile Include="Apps\ApplicationInstance.cs" />
-    <Compile Include="Apps\IApplication.cs" />
-    <Compile Include="Apps\IApplicationMarker.cs" />
+    <Compile Include="Apps\IApplicationInstance.cs" />
+    <Compile Include="Apps\IApplicationDefinition.cs" />
     <Compile Include="Apps\IDispatcher.cs" />
     <Compile Include="Apps\IRequest.cs" />
     <Compile Include="Apps\Rebootable.cs" />
@@ -80,8 +80,9 @@
     <Compile Include="Introspection\ProbeResultExtensions.cs" />
     <Compile Include="Introspection\ProbeSiteExtensions.cs" />
     <Compile Include="Introspection\ScopeProbeContext.cs" />
+    <Compile Include="Meta\ApplicationMetaData.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Startup\IWebStartupStep.cs" />
+    <Compile Include="Startup\IWebApiStartupStep.cs" />
     <Compile Include="Startup\StartupBootstrapper.cs" />
     <Compile Include="Startup\StartUpFeature.cs" />
     <Compile Include="Startup\StartupStep.cs" />

--- a/src/Chassis/Meta/ApplicationMetaData.cs
+++ b/src/Chassis/Meta/ApplicationMetaData.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using Autofac;
+using Chassis.Apps;
+using Chassis.Features;
+using Chassis.Tenants;
+
+namespace Chassis.Meta
+{
+    public class ApplicationMetaData
+    {
+        public ApplicationMetaData(IApplicationDefinition appDef, IEnumerable<Module> loadedModules, IEnumerable<Feature> loadedFeatures, IEnumerable<TenantOverrides> loadedTenants, TimeSpan stopwatchElapsed)
+        {
+            Name = appDef.GetType().Name;
+            LoadedModules = loadedModules;
+            LoadedFeatures = loadedFeatures;
+            LoadedTenants = loadedTenants;
+            TimeToBoot = stopwatchElapsed;
+        }
+
+        public string Name { get; }
+        public IEnumerable<Module> LoadedModules { get; }
+        public IEnumerable<Feature> LoadedFeatures { get; }
+        public IEnumerable<TenantOverrides> LoadedTenants { get; }
+        public TimeSpan TimeToBoot { get; }
+
+    }
+}

--- a/src/Chassis/Startup/IWebApiStartupStep.cs
+++ b/src/Chassis/Startup/IWebApiStartupStep.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using System.Web.Http;
+
+namespace Chassis.Startup
+{
+    public interface IWebApiStartupStep
+    {
+        Task Configure(HttpConfiguration cfg);
+    }
+}

--- a/src/Chassis/Startup/IWebStartupStep.cs
+++ b/src/Chassis/Startup/IWebStartupStep.cs
@@ -1,9 +1,0 @@
-﻿using System.Web.Http;
-
-namespace Chassis.Startup
-{
-    public interface IWebStartupStep
-    {
-        void Configure(HttpConfiguration cfg);
-    }
-}

--- a/src/Chassis/Startup/StartUpFeature.cs
+++ b/src/Chassis/Startup/StartUpFeature.cs
@@ -21,12 +21,12 @@ namespace Chassis.Startup
                     .AsSelf();
             }
 
-            var webActions = pool.FindImplementorsOf<IWebStartupStep>();
+            var webActions = pool.FindImplementorsOf<IWebApiStartupStep>();
 
             foreach (var action in webActions)
             {
                 builder.RegisterType(action)
-                    .As<IWebStartupStep>()
+                    .As<IWebApiStartupStep>()
                     .AsSelf();
             }
         }

--- a/src/Chassis/Startup/StartupStep.cs
+++ b/src/Chassis/Startup/StartupStep.cs
@@ -1,7 +1,9 @@
-﻿namespace Chassis.Startup
+﻿using System.Threading.Tasks;
+
+namespace Chassis.Startup
 {
     public interface IStartupStep
     {
-        void Execute();
+        Task Execute();
     }
 }

--- a/src/tests/Chassis.UnitTests/Features/FeatureTests.cs
+++ b/src/tests/Chassis.UnitTests/Features/FeatureTests.cs
@@ -1,4 +1,10 @@
-﻿using Chassis.Features;
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Autofac;
+using Chassis.Apps;
+using Chassis.Features;
+using Chassis.Meta;
+using Chassis.Types;
 using NUnit.Framework;
 using Shouldly;
 
@@ -20,6 +26,22 @@ namespace Chassis.UnitTests.Features
             sf.ToString().ShouldBe("Sample");
         }
 
+        [Test]
+        public async Task ShouldRegisterFeature()
+        {
+            using (var app = await AppFactory.Build<SampleApp>())
+            {
+                app.Container.Resolve<ApplicationMetaData>().LoadedFeatures.Count().ShouldBe(1);
+            }
+        }
+
+        class SampleApp : IApplicationDefinition
+        {
+            public void ConfigureContainer(TypePool pool, ContainerBuilder builder)
+            {
+
+            }
+        }
 
         class SampleFeature : Feature { }
     }


### PR DESCRIPTION
In pursuit of `async` all the way - might as well start at the foundation.

This also improves some naming of things, namely around

`IApplicationMarker` -> `IApplicationDefinition`

A new class `ApplicationMetaData` which exposes a `Name` property as well, which was needed for `Consul` service registration.